### PR TITLE
Fix: set clck.ru max link length to real probed value

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These are the maximum link lengths on some apps and browsers.
 | Slack   |   4,000    |
 | QR Code |   2,610    |
 | Bit.ly  |   2,048    |
-| Clck.ru |   4,050    |
+| Clck.ru |   3,810    |
 
 DoPaste noty you when generated link is too long for each App.
 

--- a/resources/app-share-settings.json
+++ b/resources/app-share-settings.json
@@ -22,7 +22,7 @@
     },
     "clck_ru": {
       "name": "Clck.ru (Yandex)",
-      "max_chars": 4050
+      "max_chars": 3810
     }
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = '20240131';
+const VERSION = '20240202';
 const PRECACHE = 'precache-' + VERSION;
 const MODES = 'modes-' + VERSION;
 


### PR DESCRIPTION
We were able to verify that the `Clck.ru` accepts links generated via DoPaste up to 3810 characters long (sometimes a little more).